### PR TITLE
feat: create add activity to UserGroup

### DIFF
--- a/app/src/androidTest/java/com/example/bubblify/service/StorageServiceTest.kt
+++ b/app/src/androidTest/java/com/example/bubblify/service/StorageServiceTest.kt
@@ -3,6 +3,7 @@ package com.example.bubblify.service
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.example.bubblify.model.Group
 import com.example.bubblify.model.User
+import com.example.bubblify.model.UserGroup
 import com.google.firebase.Firebase
 import com.google.firebase.auth.auth
 import com.google.firebase.firestore.firestore
@@ -18,11 +19,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class StorageServiceTest {
 
-    private val EMAIL = "unit-test@gmail.com"
-    private val USERNAME = "unit-test"
-    private val PASSWORD = "wH5^34ATr^\$^Y6"
-
-
     private var firestore = Firebase.firestore
     private lateinit var storageService: StorageService
     private lateinit var accountService: AccountService
@@ -37,68 +33,132 @@ class StorageServiceTest {
 
     @Test
     fun createUpdateDeleteGroup() = runTest {
-        Firebase.auth.signInWithEmailAndPassword(EMAIL, PASSWORD).await()
-
+        // Arrange
         val groupName = "Test Group"
-        val updatedGroupName = "Test Group 2"
+        val updatedGroupName = GROUP_1
 
-        // Create a group
+        // Act: Create a group
         val groupReference = storageService.createGroup(Group(groupName))
 
+        // Assert: Create a group
         var group = storageService.getGroup(groupReference.id)
         assertEquals(groupName, group!!.name)
 
-        // Update the group
+        // Act: Update the group
         group.name = updatedGroupName
         storageService.updateGroup(groupReference.id, group)
 
+        // Assert: Update the group
         group = storageService.getGroup(groupReference.id)
         assertEquals(updatedGroupName, group!!.name)
 
-        // Delete the group
+        // Act: Delete the group
         storageService.deleteGroup(groupReference.id)
     }
 
     @Test
     fun getAllGroupsFromCurrentUser() = runTest {
-        Firebase.auth.signInWithEmailAndPassword(EMAIL, PASSWORD).await()
-
+        // Act
         val groups = storageService.getAllGroupsFromCurrentUser()
+
+        // Assert
         assertNotNull(groups)
-
-        assertContains(groups, "Test Group 1")
-        assertContains(groups, "Test Group 2")
-        assertContains(groups, "Test Group 3")
-
+        assertContains(groups, GROUP_1)
+        assertContains(groups, GROUP_2)
+        assertContains(groups, GROUP_3)
     }
 
     @Test
     fun createDeleteUser() = runTest {
-        Firebase.auth.signInWithEmailAndPassword(EMAIL, PASSWORD).await()
-
+        // Arrange
         val randomId = Util.autoId()
+
+        // Act
         storageService.createUser(randomId, User(USERNAME, EMAIL))
 
+        // Assert
         val result = firestore.collection("Users").document(randomId).get().await().toObject<User>()
 
         assertEquals(EMAIL, result!!.email)
         assertEquals(USERNAME, result.username)
 
+        // Clean up
         storageService.deleteUser(randomId)
 
     }
 
     @Test
     fun getUser() = runTest {
+        // Act
         val userReference = storageService.getCurrentUser()
 
+        // Assert
         assertNotNull(userReference)
         assertEquals(EMAIL, userReference.data.email)
         assertEquals(USERNAME, userReference.data.username)
-        assertEquals(accountService.currentUserId, userReference.id)
+        assertEquals(accountService.currentUserId, userReference.reference.id)
+    }
+
+    @Test
+    fun addRemoveUserGroup() = runTest {
+        // Arrange
+        val groupName = "Test addRemoveUserGroup"
+        val userReference = storageService.getCurrentUser()
+        val groupReference = storageService.createGroup(Group(groupName))
+
+        // Act
+        storageService.addUserToGroup(userReference.reference, groupReference)
+
+        // Assert
+        val groups = storageService.getAllGroupsWithReferenceFromCurrentUser()
+        assertTrue(groups.any { it.reference == groupReference })
+
+
+        // Clean up
+        storageService.removeUserFromGroup(userReference.reference, groupReference)
+        storageService.deleteGroup(groupReference.id)
+    }
+
+    @Test
+    fun setActivityForUserInGroup() = runTest {
+        // Arrange
+        val userReference = storageService.getCurrentUser()
+        val activityReference = firestore.collection(StorageService.ACTIVITY_COLLECTION)
+            .document("M1HBlxTypU3MVsz4VxKQ")
+        val groupReference =
+            firestore.collection(StorageService.GROUP_COLLECTION).document("nLCaoyJWKw59XNuf0Frj")
+
+        // Act
+        storageService.setActivityForUserInGroup(
+            activityReference,
+            userReference.reference,
+            groupReference
+        )
+
+        // Assert
+        val userGroup = firestore.collection(StorageService.USER_GROUP_COLLECTION)
+            .whereEqualTo(StorageService.USER_ID_FIELD, userReference.reference)
+            .whereEqualTo(StorageService.GROUP_ID_FIELD, groupReference)
+            .get().await().documents.first().toObject<UserGroup>()
+        assertEquals(activityReference, userGroup!!.activityId)
+
+        // Clean up
+        storageService.setActivityForUserInGroup(null, userReference.reference, groupReference)
     }
 
     private fun assertContains(groups: List<Group>, s: String) {
         assertTrue(groups.any { it.name == s })
+    }
+
+    companion object {
+        // Unit test account
+        private const val EMAIL = "unit-test@gmail.com"
+        private const val USERNAME = "unit-test"
+        private const val PASSWORD = "wH5^34ATr^\$^Y6"
+
+        // Groups
+        private const val GROUP_1 = "Test Group 1"
+        private const val GROUP_2 = "Test Group 2"
+        private const val GROUP_3 = "Test Group 3"
     }
 }

--- a/app/src/main/java/com/example/bubblify/model/Reference.kt
+++ b/app/src/main/java/com/example/bubblify/model/Reference.kt
@@ -1,6 +1,8 @@
 package com.example.bubblify.model
 
+import com.google.firebase.firestore.DocumentReference
+
 data class Reference<T>(
-    val id: String,
+    val reference: DocumentReference,
     val data: T
 )

--- a/app/src/main/java/com/example/bubblify/model/UserGroup.kt
+++ b/app/src/main/java/com/example/bubblify/model/UserGroup.kt
@@ -3,8 +3,8 @@ package com.example.bubblify.model
 import com.google.firebase.firestore.DocumentReference
 
 data class UserGroup (
-    val userId: DocumentReference,
-    val groupId: DocumentReference,
+    val userId: DocumentReference? = null,
+    val groupId: DocumentReference? = null,
     val activityId: DocumentReference? = null,
-    val state: UserGroupState,
+    val state: UserGroupState = UserGroupState.INVITED
 )

--- a/app/src/main/java/com/example/bubblify/service/StorageService.kt
+++ b/app/src/main/java/com/example/bubblify/service/StorageService.kt
@@ -23,18 +23,20 @@ constructor(
     //======================== GROUP METHODS ========================//
     //===============================================================//
 
+    @Deprecated("Use getAllGroupsWithReferenceFromCurrentUser instead")
     suspend fun getGroups(): List<Group>? =
         firestore.collection(GROUP_COLLECTION).get().await().toObjects()
 
     suspend fun getGroup(groupId: String): Group? =
         firestore.collection(GROUP_COLLECTION).document(groupId).get().await().toObject()
 
-    // Get all groups from the database
+    @Deprecated("Use getAllGroupsWithReferenceFromCurrentUser instead")
     suspend fun getAllGroups(): List<Group> {
         return firestore.collection(GROUP_COLLECTION).get().await().toObjects()
     }
 
     // Get all the groups from the current User
+    @Deprecated("Use getAllGroupsWithReferenceFromCurrentUser instead")
     suspend fun getAllGroupsFromCurrentUser(): List<Group> {
         // Get the current user ID
         val userReference = firestore.collection(USER_COLLECTION).document(auth.currentUserId)
@@ -48,6 +50,33 @@ constructor(
             .mapNotNull { document ->
                 val groupReference = document.getDocumentReference(GROUP_ID_FIELD)
                 groupReference!!.get().await().toObject<Group>()
+            }
+            .toList()
+        // Return the list
+        return groups
+    }
+
+    suspend fun getAllGroupsWithReferenceFromCurrentUser(): List<Reference<Group>> {
+        // Get the current user ID
+        val userReference = firestore.collection(USER_COLLECTION).document(auth.currentUserId)
+        // Fetch all the groups where the user are
+        val userGroups =
+            firestore.collection(USER_GROUP_COLLECTION).whereEqualTo(USER_ID_FIELD, userReference)
+                .get().await()
+        // Fetch all the groups where the reference (groupId) corresponding
+        val groups = userGroups.documents
+            .filter { it.exists() }
+            .mapNotNull { document ->
+                val groupReference = document.getDocumentReference(GROUP_ID_FIELD)
+                val group = groupReference!!.get().await().toObject<Group>()
+                if (group == null) {
+                    document.reference.delete().await()
+                    return@mapNotNull null
+                }
+                Reference(
+                    groupReference,
+                    group
+                )
             }
             .toList()
         // Return the list
@@ -69,7 +98,8 @@ constructor(
 
     suspend fun deleteGroup(groupId: String) {
         val groupReference = firestore.collection(GROUP_COLLECTION).document(groupId)
-        firestore.collection(USER_GROUP_COLLECTION).whereEqualTo(GROUP_ID_FIELD, groupId).get()
+        firestore.collection(USER_GROUP_COLLECTION).whereEqualTo(GROUP_ID_FIELD, groupReference)
+            .get()
             .await()
             .documents.forEach {
                 it.reference.delete().await()
@@ -77,44 +107,80 @@ constructor(
         groupReference.delete().await()
     }
 
-    suspend fun delete(groupId: String) {
-        firestore.collection(GROUP_COLLECTION).document(groupId).delete().await()
+    //===============================================================//
+    //======================== USER METHODS =========================//
+    //===============================================================//
+
+    suspend fun getCurrentUser(): Reference<User> {
+        val documentReference =
+            firestore.collection(USER_COLLECTION).document(auth.currentUserId).get().await()
+        return Reference(
+            documentReference.reference,
+            documentReference.toObject()!!
+        )
     }
-        //===============================================================//
-        //======================== USER METHODS =========================//
-        //===============================================================//
 
-        suspend fun getCurrentUser(): Reference<User> {
-            val documentReference =
-                firestore.collection(USER_COLLECTION).document(auth.currentUserId).get().await()
-            return Reference(
-                documentReference.id,
-                documentReference.toObject()!!
-            )
-        }
-
-        suspend fun createUser(userId: String, user: User) {
-            firestore.collection(USER_COLLECTION).document(userId).set(user).await()
-        }
-
-
-        suspend fun deleteUser(userId: String) {
-            firestore.collection(USER_COLLECTION).document(userId).delete().await()
-        }
-
-
-        // ================= Constants ================================ //
-        companion object {
-            // Fields
-            private const val USER_ID_FIELD = "userId"
-            private const val GROUP_ID_FIELD = "groupId"
-            private const val UUID_FIELD = "uuid"
-            private const val ACTIVITY_ID_FIELD = "activityId"
-
-            // Collection/Documents Constants
-            private const val USER_GROUP_COLLECTION = "UsersGroups"
-            private const val GROUP_COLLECTION = "Groups"
-            private const val USER_COLLECTION = "Users"
-            private const val ACTIVITY_COLLECTION = "Activities"
-        }
+    suspend fun createUser(userId: String, user: User) {
+        firestore.collection(USER_COLLECTION).document(userId).set(user).await()
     }
+
+    suspend fun deleteUser(userId: String) {
+        firestore.collection(USER_COLLECTION).document(userId).delete().await()
+    }
+
+    //===============================================================//
+    //======================== UserGroup METHODS ====================//
+    //===============================================================//
+    suspend fun setActivityForUserInGroup(
+        activityReference: DocumentReference?,
+        userReference: DocumentReference,
+        groupReference: DocumentReference
+    ) {
+        val userGroup = firestore.collection(USER_GROUP_COLLECTION)
+            .whereEqualTo(USER_ID_FIELD, userReference)
+            .whereEqualTo(GROUP_ID_FIELD, groupReference)
+            .get()
+            .await()
+
+        userGroup.documents.first()
+            .reference
+            .update(ACTIVITY_ID_FIELD, activityReference)
+            .await()
+    }
+
+    suspend fun addUserToGroup(
+        userReference: DocumentReference,
+        groupReference: DocumentReference
+    ): DocumentReference {
+        val userGroup = UserGroup(userReference, groupReference, null, UserGroupState.INVITED)
+        return firestore.collection(USER_GROUP_COLLECTION).add(userGroup).await()
+    }
+
+    suspend fun removeUserFromGroup(
+        userReference: DocumentReference,
+        groupReference: DocumentReference
+    ) {
+        firestore.collection(USER_GROUP_COLLECTION)
+            .whereEqualTo(USER_ID_FIELD, userReference)
+            .whereEqualTo(GROUP_ID_FIELD, groupReference)
+            .get()
+            .await()
+            .documents.forEach {
+                it.reference.delete().await()
+            }
+    }
+
+    // ================= Constants ================================ //
+    companion object {
+        // Fields
+        const val USER_ID_FIELD = "userId"
+        const val GROUP_ID_FIELD = "groupId"
+        const val ACTIVITY_ID_FIELD = "activityId"
+
+        // Collection/Documents Constants
+        const val USER_GROUP_COLLECTION = "UsersGroups"
+        const val GROUP_COLLECTION = "Groups"
+        const val USER_COLLECTION = "Users"
+        const val ACTIVITY_COLLECTION = "Activities"
+    }
+}


### PR DESCRIPTION
I created the `Reference` class to have the data and the reference of the object together.
To not break the existing code so I created a new method `StorageService.getAllGroupsWithReferenceFromCurrentUser` and marked the old one as deprecated. I think it will help to modify the groups...

I also created the following new features in the `StorageService`:
 `StorageService.setActivityForUserInGroup`
 `StorageService.addUserToGroup`
 `StorageService.removeUserFromGroup`